### PR TITLE
Fix error when ranking command invoked

### DIFF
--- a/okimochi/index.js
+++ b/okimochi/index.js
@@ -84,13 +84,14 @@ function makeTraceForPlotly(userinfo, hue){
 
 
 async function PromisePlotRankingChart(){
-  let x;
+  let userinfos;
   try {
     userinfos = await PromiseGetAllUsersDeposit()
   } catch(e) {
     throw e
   }
 
+  let u;
   let data = [];
   for (u of userinfos){
     data.push(makeTraceForPlotly(u));


### PR DESCRIPTION
This commit, https://github.com/campfire-inc/OKIMOCHI/commit/3677838f6e5694d6d99450e02ad8b5a9d4994191,  introduced `use strict` but I found `ReferenceError` occurred.

It's because several variables are not defined in spite of declaring `use strict` at the top of the code.